### PR TITLE
升级 LightRpc 包版本并替换为异步方法调用

### DIFF
--- a/demo/LuYao.LightRpc.Demo.Client/LuYao.LightRpc.Demo.Client.csproj
+++ b/demo/LuYao.LightRpc.Demo.Client/LuYao.LightRpc.Demo.Client.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="LuYao.LightRpc.Newtonsoft" Version="1.0.2" />
+		<PackageReference Include="LuYao.LightRpc.Newtonsoft" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/demo/LuYao.LightRpc.Demo.MinimalApi/Program.cs
+++ b/demo/LuYao.LightRpc.Demo.MinimalApi/Program.cs
@@ -22,7 +22,7 @@ app.Map("/", async (
     {
         data = await reader.ReadToEndAsync();
     }
-    var result = await server.Invoke(action, data);
+    var result = await server.InvokeAsync(action, data);
     var ret = new RpcHttpResult(result);
     return ret;
 });

--- a/demo/LuYao.LightRpc.Demo/LuYao.LightRpc.Demo.csproj
+++ b/demo/LuYao.LightRpc.Demo/LuYao.LightRpc.Demo.csproj
@@ -6,9 +6,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="LuYao.LightRpc" Version="1.0.2" />
-		<PackageReference Include="LuYao.LightRpc.Newtonsoft" Version="1.0.2" />
-		<PackageReference Include="LuYao.LightRpc.SourceGenerators" Version="1.0.2" />
+		<PackageReference Include="LuYao.LightRpc" Version="1.1.0" />
+		<PackageReference Include="LuYao.LightRpc.Newtonsoft" Version="1.1.0" />
+		<PackageReference Include="LuYao.LightRpc.SourceGenerators" Version="1.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/demo/fc/LuYao.LightRpc.Demo.Functions.InAliyun/Program.cs
+++ b/demo/fc/LuYao.LightRpc.Demo.Functions.InAliyun/Program.cs
@@ -27,7 +27,7 @@ app.Map("/", async (
 {
     if (action is null) action = string.Empty;
     string data = body is not null ? body.ToString() : string.Empty;
-    var result = await server.Invoke(action, data);
+    var result = await server.InvokeAsync(action, data);
     var ret = new RpcHttpResult(result);
     return ret;
 });

--- a/demo/fc/LuYao.LightRpc.Demo.Functions.InAzure/Handler.cs
+++ b/demo/fc/LuYao.LightRpc.Demo.Functions.InAzure/Handler.cs
@@ -22,7 +22,7 @@ public class Handler
         string data = await req.ReadAsStringAsync() ?? string.Empty;
         var response = req.CreateResponse();
         response.Headers.Add("Content-Type", "application/json");
-        var result = await _mainServer.Invoke(action, data);
+        var result = await _mainServer.InvokeAsync(action, data);
         response.StatusCode = System.Net.HttpStatusCode.OK;
         if (result != null)
         {


### PR DESCRIPTION
更新了 `LuYao.LightRpc.Newtonsoft` 包的版本，从 `1.0.2` 升级到 `1.1.0`。 在 `Program.cs` 和 `Handler.cs` 文件中，将 `Invoke` 方法调用替换为 `InvokeAsync` 方法调用。 更新了 `LuYao.LightRpc.Demo.csproj` 文件中的包版本：
  * `LuYao.LightRpc` 从 `1.0.2` 升级到 `1.1.0`。
  * `LuYao.LightRpc.Newtonsoft` 从 `1.0.2` 升级到 `1.1.0`。
  * `LuYao.LightRpc.SourceGenerators` 从 `1.0.2` 升级到 `1.1.0`。